### PR TITLE
"token_exchange" grant type

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -22,10 +22,14 @@ class Authorization < ActiveRecord::Base
       .presence || ["all"]
   end
 
-  def includes_scope?(test_scope)
+  def self.scope_included?(scope, test_scope)
     return true if scope == "all"
     scopes = scope.split
     test_scope.split.all? { |s| scopes.include?(s) }
+  end
+
+  def includes_scope?(test_scope)
+    Authorization.scope_included?(scope, test_scope)
   end
 
   def add_scope(new_scopes)

--- a/app/models/oauth2/token_endpoint.rb
+++ b/app/models/oauth2/token_endpoint.rb
@@ -1,3 +1,5 @@
+require_relative "./token_exchange_extension"
+
 class Oauth2::TokenEndpoint
   def call(env)
     authenticator.call(env)
@@ -57,6 +59,16 @@ class Oauth2::TokenEndpoint
         new_access_token = access_token.class.create! client_id: access_token.client_id, resource_id: access_token.resource_id, user_id: access_token.user_id, scope: access_token.scope
         res.access_token = new_access_token.to_token
         res.access_token.refresh_token = refresh_token.token
+      when :token_exchange
+        existing_token = BearerAccessToken.valid.find_by_client_id_and_token(app.id, req.access_token) || req.invalid_grant!
+        new_scope = Authorization.normalize_scope(req.scope).join(' ')
+
+        unless Authorization.scope_included?(existing_token.scope, new_scope)
+          req.invalid_grant!
+        end
+
+        new_token = existing_token.class.create! client_id: app.id, resource_id: existing_token.resource_id, user_id: existing_token.user_id, scope: new_scope
+        res.access_token = new_token.to_token()
       else
         req.unsupported_grant_type!
       end

--- a/app/models/oauth2/token_exchange_extension.rb
+++ b/app/models/oauth2/token_exchange_extension.rb
@@ -1,0 +1,36 @@
+require "oauth2"
+
+module Rack
+  module OAuth2
+    module Server
+      class Token
+        module Extension
+          class TokenExchange < Abstract::Handler
+            class << self
+              def grant_type_for?(grant_type)
+                grant_type == 'token_exchange'
+              end
+            end
+
+            def _call(env)
+              @request  = Request.new(env)
+              @response = Response.new(request)
+              super
+            end
+
+            class Request < Token::Request
+              attr_required :access_token
+
+              def initialize(env)
+                super
+                @grant_type = :token_exchange
+                @access_token = params['access_token']
+                attr_missing!
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added "token_exchange" grant type to obtain new temporal token based on an existing one.

Currently, only bearer tokens can be exchanged. MAC tokens could come later, but it has the added complexity of having to verify the request to make sure the client has access to the entire token.